### PR TITLE
Add BMP loader and display

### DIFF
--- a/encoder/encoder.gprj
+++ b/encoder/encoder.gprj
@@ -10,7 +10,7 @@
         <File path="src/main.v" type="file.verilog" enable="1"/>
         <File path="src/dvi_pmod.v" type="file.verilog" enable="1"/>
         <File path="src/hdmi_tx.v" type="file.verilog" enable="1"/>
-        <File path="src/pattern_gen.v" type="file.verilog" enable="1"/>
+        <File path="src/video_timing.v" type="file.verilog" enable="1"/>
         <File path="src/gowin_pll_50m_250m.v" type="file.verilog" enable="1"/>
         <File path="src/sd_file_reader.v" type="file.verilog" enable="1"/>
         <File path="src/sd_reader.v" type="file.verilog" enable="1"/>

--- a/encoder/src/hdmi_tx.v
+++ b/encoder/src/hdmi_tx.v
@@ -58,48 +58,47 @@ module hdmi_tx (
         end
     endfunction
 
-    reg [9:0] tmds_red, tmds_green, tmds_blue, tmds_clock;
+    reg [9:0] tmds_red, tmds_green, tmds_blue;
 
     always @(posedge pix_clk) begin
         tmds_red   <= tmds_encode(red, 0, 0, de);
         tmds_green <= tmds_encode(green, 0, 0, de);
         tmds_blue  <= tmds_encode(blue, hsync, vsync, de);
-        tmds_clock <= 10'b0000011111; // clock pattern
     end
 
-    reg [9:0] shift_red   = 0;
-    reg [9:0] shift_green = 0;
-    reg [9:0] shift_blue  = 0;
-    reg [9:0] shift_clock = 0;
-    reg [3:0] shift_cnt   = 0;
+    // Serialize the 10-bit TMDS words using the Gowin OSER10 primitives.
+    wire [9:0] tmds_bus [2:0];
+    assign tmds_bus[0] = tmds_red;
+    assign tmds_bus[1] = tmds_green;
+    assign tmds_bus[2] = tmds_blue;
 
-    always @(posedge tmds_clk or posedge rst) begin
-        if (rst) begin
-            shift_cnt   <= 0;
-            shift_red   <= 0;
-            shift_green <= 0;
-            shift_blue  <= 0;
-            shift_clock <= 0;
-        end else begin
-            if (shift_cnt == 0) begin
-                shift_cnt   <= 9;
-                shift_red   <= tmds_red;
-                shift_green <= tmds_green;
-                shift_blue  <= tmds_blue;
-                shift_clock <= tmds_clock;
-            end else begin
-                shift_cnt   <= shift_cnt - 1;
-                shift_red   <= {1'b0, shift_red[9:1]};
-                shift_green <= {1'b0, shift_green[9:1]};
-                shift_blue  <= {1'b0, shift_blue[9:1]};
-                shift_clock <= {1'b0, shift_clock[9:1]};
-            end
+    wire [2:0] tmds_data;
+
+    genvar i;
+    generate
+        for (i = 0; i < 3; i = i + 1) begin : ser
+            OSER10 gwSer (
+                .Q   (tmds_data[i]),
+                .D0  (tmds_bus[i][0]),
+                .D1  (tmds_bus[i][1]),
+                .D2  (tmds_bus[i][2]),
+                .D3  (tmds_bus[i][3]),
+                .D4  (tmds_bus[i][4]),
+                .D5  (tmds_bus[i][5]),
+                .D6  (tmds_bus[i][6]),
+                .D7  (tmds_bus[i][7]),
+                .D8  (tmds_bus[i][8]),
+                .D9  (tmds_bus[i][9]),
+                .PCLK(pix_clk),
+                .FCLK(tmds_clk),
+                .RESET(rst)
+            );
         end
-    end
+    endgenerate
 
-    assign tmds_red_p   = shift_red[0];
-    assign tmds_green_p = shift_green[0];
-    assign tmds_blue_p  = shift_blue[0];
-    assign tmds_clk_p   = shift_clock[0];
+    assign tmds_red_p   = tmds_data[0];
+    assign tmds_green_p = tmds_data[1];
+    assign tmds_blue_p  = tmds_data[2];
+    assign tmds_clk_p   = pix_clk;
 
 endmodule

--- a/encoder/src/main.v
+++ b/encoder/src/main.v
@@ -6,7 +6,6 @@ module top#(
 (
     input clk,
     input key,  // active-high pushbutton
-    input key2,
 
     output led_done,   // onboard LED for file_found
     output led_ready,  // onboard LED for outen
@@ -27,9 +26,6 @@ module top#(
 wire key_clean;
 debounce db(.clk(clk), .noisy(key), .clean(key_clean));
 
-// Debounce for key2
-wire key2_clean;
-debounce db2(.clk(clk), .noisy(key2), .clean(key2_clean));
 
 // Force SD DAT1~3 high to stay in SD bus mode
 assign sddat1 = 1'b1;
@@ -45,8 +41,8 @@ wire outen;
 wire [7:0] outbyte;
 
 sd_file_reader #(
-    .FILE_NAME_LEN(7),
-    .FILE_NAME("hex.txt"),
+    .FILE_NAME_LEN(9),
+    .FILE_NAME("image.bmp"),
     .CLK_DIV(3'd2),
     .SIMULATE(0)
 ) sd_inst (
@@ -62,50 +58,74 @@ sd_file_reader #(
     .outen(outen),
     .outbyte(outbyte)
 );
-// Displayed hex digits for the two-digit 7-segment module
+
+// framebuffer for BMP image
+localparam H_ACTIVE = 640;
+localparam V_ACTIVE = 480;
+localparam FRAME_PIXELS = H_ACTIVE*V_ACTIVE;
+localparam ADDR_WIDTH = 19;
+
+reg [23:0] framebuffer [0:FRAME_PIXELS-1];
+reg [ADDR_WIDTH-1:0] fb_wr_addr = 0;
+reg [1:0] byte_phase = 0;
+reg [23:0] pix_buf = 0;
+reg [31:0] byte_index = 0;
+
+always @(posedge clk or posedge key_clean) begin
+    if (key_clean) begin
+        fb_wr_addr <= 0;
+        byte_phase <= 0;
+        byte_index <= 0;
+        status <= STATUS_INIT;
+    end else begin
+        if (card_stat == 4'd8)
+            status <= STATUS_SD_OK;
+        if (file_found)
+            status <= STATUS_FILE_OK;
+
+        if (file_found && outen && fb_wr_addr < FRAME_PIXELS) begin
+            status <= STATUS_LOADING;
+            byte_index <= byte_index + 1;
+            if (byte_index >= 54) begin
+                case(byte_phase)
+                    2'd0: pix_buf[7:0]   <= outbyte;       // B
+                    2'd1: pix_buf[15:8]  <= outbyte;       // G
+                    2'd2: begin
+                        pix_buf[23:16] <= outbyte;          // R
+                        framebuffer[fb_wr_addr] <= pix_buf;
+                        fb_wr_addr <= fb_wr_addr + 1;
+                    end
+                endcase
+                byte_phase <= byte_phase + 1;
+                if (byte_phase == 2)
+                    byte_phase <= 0;
+                if (fb_wr_addr == FRAME_PIXELS-1)
+                    status <= STATUS_DISPLAY;
+            end
+        end
+    end
+end
+// 7-segment status codes
+// 0 : Initializing
+// 1 : SD card ready
+// 2 : File found
+// 3 : Loading image
+// 4 : Displaying image
+// E : Error
+localparam STATUS_INIT    = 4'h0;
+localparam STATUS_SD_OK   = 4'h1;
+localparam STATUS_FILE_OK = 4'h2;
+localparam STATUS_LOADING = 4'h3;
+localparam STATUS_DISPLAY = 4'h4;
+localparam STATUS_ERR     = 4'hE;
+
+reg [3:0] status = STATUS_INIT;
 reg [3:0] digit_high = 4'h0;
-reg [3:0] digit_low  = 4'h0;
-
-reg [8:0] byte_index = 0;
-reg [8:0] max_index = 0;
-reg [7:0] byte_buffer [0:511];
-
-reg key2_prev = 0;
-reg outen_prev = 0;
-reg shown_first_byte = 0;
+reg [3:0] digit_low  = STATUS_INIT;
 
 always @(posedge clk) begin
-    // Rising edge of outen (new byte available)
-    outen_prev <= outen;
-    if (outen && ~outen_prev) begin
-        byte_buffer[max_index] <= outbyte;
-        max_index <= max_index + 1;
-
-        if (~shown_first_byte) begin
-            digit_high <= outbyte[3:0]; 
-            digit_low  <= outbyte[7:4]; 
-            shown_first_byte <= 1;
-            byte_index <= 1;
-        end
-
-    end
-
-    // Rising edge of key2 (advance display)
-    key2_prev <= key2_clean;
-    if (key2_clean && ~key2_prev && byte_index < max_index) begin
-        digit_high <= byte_buffer[byte_index][3:0];
-        digit_low  <= byte_buffer[byte_index][7:4];
-        byte_index <= byte_index + 1;
-    end
-
-    // Reset when key is held
-    if (key_clean) begin
-        byte_index <= 0;
-        max_index <= 0;
-        digit_high <= 4'h0;
-        digit_low  <= 4'h0;
-        shown_first_byte <= 0;  
-    end
+    digit_high <= 4'h0;
+    digit_low  <= status;
 end
 
 // Generate 25 MHz pixel clock from the 50 MHz input
@@ -121,19 +141,27 @@ gowin_pll_50m_250m pll_video(
     .clkin(clk)
 );
 
-// Simple pattern generator
+// Video timing generator
 wire       v_hsync, v_vsync, v_de;
-wire [7:0] v_r, v_g, v_b;
-pattern_gen pat(
+wire [11:0] px;
+wire [11:0] py;
+video_timing timing_inst(
     .clk(pix_clk),
     .rst(key_clean),
+    .x(px),
+    .y(py),
     .hsync(v_hsync),
     .vsync(v_vsync),
-    .de(v_de),
-    .red(v_r),
-    .green(v_g),
-    .blue(v_b)
+    .de(v_de)
 );
+
+wire [23:0] pixel_data;
+wire [18:0] rd_addr;
+assign rd_addr = (py << 9) + (py << 7) + px;
+assign pixel_data = framebuffer[rd_addr];
+wire [7:0] v_r = pixel_data[23:16];
+wire [7:0] v_g = pixel_data[15:8];
+wire [7:0] v_b = pixel_data[7:0];
 
 // TMDS transmitter
 wire tmds_clk_p, tmds_red_p, tmds_green_p, tmds_blue_p;

--- a/encoder/src/video_timing.v
+++ b/encoder/src/video_timing.v
@@ -1,0 +1,44 @@
+module video_timing #(
+    parameter H_ACTIVE = 640,
+    parameter H_FP     = 16,
+    parameter H_SYNC   = 96,
+    parameter H_BP     = 48,
+    parameter V_ACTIVE = 480,
+    parameter V_FP     = 10,
+    parameter V_SYNC   = 2,
+    parameter V_BP     = 33
+)(
+    input  clk,
+    input  rst,
+    output reg [11:0] x = 0,
+    output reg [11:0] y = 0,
+    output hsync,
+    output vsync,
+    output de
+);
+
+    localparam H_TOTAL = H_ACTIVE + H_FP + H_SYNC + H_BP;
+    localparam V_TOTAL = V_ACTIVE + V_FP + V_SYNC + V_BP;
+
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            x <= 0;
+            y <= 0;
+        end else begin
+            if (x == H_TOTAL-1) begin
+                x <= 0;
+                if (y == V_TOTAL-1)
+                    y <= 0;
+                else
+                    y <= y + 1;
+            end else begin
+                x <= x + 1;
+            end
+        end
+    end
+
+    assign hsync = (x >= H_ACTIVE + H_FP) && (x < H_ACTIVE + H_FP + H_SYNC);
+    assign vsync = (y >= V_ACTIVE + V_FP) && (y < V_ACTIVE + V_FP + V_SYNC);
+    assign de    = (x < H_ACTIVE) && (y < V_ACTIVE);
+
+endmodule


### PR DESCRIPTION
## Summary
- replace pattern generator with video timing logic
- load `image.bmp` from the SD card and store pixels in a framebuffer
- display framebuffer via HDMI
- show status codes on the 7‑segment display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684604cefb8483218bf13bfbaac2c015